### PR TITLE
 Fix adjustability enum for hidden value

### DIFF
--- a/controls/models.py
+++ b/controls/models.py
@@ -7,7 +7,7 @@ class Control(models.Model):
     class Adjustability(models.TextChoices):
         OPTIONAL = 'O', 'Optional'
         MANDATORY = 'M', 'Mandatory'
-        HIDDEN = 'H', 'Hidden'
+        HIDDEN = 'N', 'Hidden'
         REQUIRED = 'R', 'Required'
 
     name = models.CharField(db_column='FieldName', primary_key=True, max_length=50)


### PR DESCRIPTION
In the [spec](https://openimis.atlassian.net/wiki/spaces/OP/pages/906788922/WA4.2+Control+table), the value for a hidden field is `N` and not `H`. The change simply fixes that.